### PR TITLE
vauban-neuroptics-alert

### DIFF
--- a/WarDroid/src/main/res/values/arrays.xml
+++ b/WarDroid/src/main/res/values/arrays.xml
@@ -154,7 +154,7 @@
         <item>Vanguard Rhino Helmet</item>
         <item>Vania Revenant Helmet</item>
         <item>Vauban Chassis</item>
-        <item>Vauban Helmet</item>
+        <item>Vauban Neuroptics</item>
         <item>Vauban Systems</item>
         <item>Vespa Nyx Helmet</item>
         <item>Virago Gara Helmet</item>


### PR DESCRIPTION
Should be Vauban Neuroptics as Vauban Helmet items are already defined.

check here
https://raidtime.net/de/game/tool/warframe/alarm/timeline/playstation/1/blueprint/vauban-neuroptics